### PR TITLE
fix linebreak not showing up using white-space: pre-line

### DIFF
--- a/src/components/course/rate.vue
+++ b/src/components/course/rate.vue
@@ -273,7 +273,7 @@
                           </v-card-actions>
                         </span>
                       </v-col>
-                      <v-col cols="12" xs="12" sm="12" md="12" lg="12" xl="12" class="pr-5">
+                      <v-col cols="12" xs="12" sm="12" md="12" lg="12" xl="12" class="pr-5" style="white-space: pre-line">
                         {{ item.comment }}
 
                         <!-- temporarily disable comment time -->


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41709023/142970334-9360e3bb-3894-4b2b-afcc-c3f620e0d9b8.png)

Line breaks now properly display on course reviews 